### PR TITLE
Add basic CLI to manage students

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# gestionetudiant
+# Gestion des élèves
+
+Cette application permet à un enseignant de gérer les informations de ses élèves via une interface en ligne de commande.
+
+## Prérequis
+
+- Python 3.12
+
+## Utilisation
+
+```bash
+python3 main.py add "Alice" 12 15.0   # Ajoute un élève
+python3 main.py list                    # Liste les élèves
+python3 main.py update 1 --grade 16.0   # Met à jour un élève
+python3 main.py remove 1                # Supprime un élève
+```
+
+Les données des élèves sont stockées dans le fichier `students.json`.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,49 @@
+import argparse
+from student_manager import StudentManager
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Gestion des élèves")
+    subparsers = parser.add_subparsers(dest="cmd")
+
+    add_parser = subparsers.add_parser("add", help="Ajouter un élève")
+    add_parser.add_argument("name")
+    add_parser.add_argument("age", type=int)
+    add_parser.add_argument("grade", type=float)
+
+    subparsers.add_parser("list", help="Lister les élèves")
+
+    remove_parser = subparsers.add_parser("remove", help="Supprimer un élève")
+    remove_parser.add_argument("id", type=int)
+
+    update_parser = subparsers.add_parser("update", help="Mettre à jour un élève")
+    update_parser.add_argument("id", type=int)
+    update_parser.add_argument("--name")
+    update_parser.add_argument("--age", type=int)
+    update_parser.add_argument("--grade", type=float)
+
+    args = parser.parse_args()
+    manager = StudentManager()
+
+    if args.cmd == "add":
+        student = manager.add_student(args.name, args.age, args.grade)
+        print(f"Élève ajouté: {student}")
+    elif args.cmd == "list":
+        for s in manager.list_students():
+            print(f"{s.id}: {s.name}, {s.age} ans, note {s.grade}")
+    elif args.cmd == "remove":
+        if manager.remove_student(args.id):
+            print("Élève supprimé")
+        else:
+            print("Élève introuvable")
+    elif args.cmd == "update":
+        if manager.update_student(args.id, args.name, args.age, args.grade):
+            print("Élève mis à jour")
+        else:
+            print("Élève introuvable")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/student_manager.py
+++ b/student_manager.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, asdict
+import json
+from typing import List, Optional
+
+
+@dataclass
+class Student:
+    id: int
+    name: str
+    age: int
+    grade: float
+
+
+class StudentManager:
+    def __init__(self, storage_path: str = "students.json"):
+        self.storage_path = storage_path
+        self.students: List[Student] = []
+        self._load()
+        self._next_id = max((s.id for s in self.students), default=0) + 1
+
+    def _load(self) -> None:
+        try:
+            with open(self.storage_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.students = [Student(**item) for item in data]
+        except FileNotFoundError:
+            self.students = []
+
+    def _save(self) -> None:
+        with open(self.storage_path, "w", encoding="utf-8") as f:
+            json.dump([asdict(s) for s in self.students], f, indent=2)
+
+    def add_student(self, name: str, age: int, grade: float) -> Student:
+        student = Student(id=self._next_id, name=name, age=age, grade=grade)
+        self._next_id += 1
+        self.students.append(student)
+        self._save()
+        return student
+
+    def list_students(self) -> List[Student]:
+        return list(self.students)
+
+    def get_student(self, student_id: int) -> Optional[Student]:
+        for student in self.students:
+            if student.id == student_id:
+                return student
+        return None
+
+    def remove_student(self, student_id: int) -> bool:
+        student = self.get_student(student_id)
+        if student:
+            self.students.remove(student)
+            self._save()
+            return True
+        return False
+
+    def update_student(
+        self,
+        student_id: int,
+        name: Optional[str] = None,
+        age: Optional[int] = None,
+        grade: Optional[float] = None,
+    ) -> bool:
+        student = self.get_student(student_id)
+        if not student:
+            return False
+        if name is not None:
+            student.name = name
+        if age is not None:
+            student.age = age
+        if grade is not None:
+            student.grade = grade
+        self._save()
+        return True

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,26 @@
+from student_manager import StudentManager
+
+
+def test_add_list_remove(tmp_path):
+    storage = tmp_path / "students.json"
+    mgr = StudentManager(str(storage))
+
+    s1 = mgr.add_student("Alice", 12, 15.5)
+    assert s1.id == 1
+    students = mgr.list_students()
+    assert len(students) == 1
+    assert students[0].name == "Alice"
+
+    assert mgr.remove_student(s1.id) is True
+    assert mgr.list_students() == []
+
+def test_update_student(tmp_path):
+    storage = tmp_path / "students.json"
+    mgr = StudentManager(str(storage))
+    s1 = mgr.add_student("Bob", 13, 14.0)
+
+    assert mgr.update_student(s1.id, grade=16.0) is True
+    student = mgr.get_student(s1.id)
+    assert student.grade == 16.0
+
+    assert mgr.update_student(999, name="ghost") is False


### PR DESCRIPTION
## Summary
- build simple command line application to manage students
- allow listing, creating, removing and updating students
- document how to use the tool
- add tests for the StudentManager logic

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447668eab8832097db8eba6a382d4a